### PR TITLE
Make OneNote writes opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A complete, robust Model Context Protocol (MCP) server for Microsoft OneNote int
 Transform your OneNote notebooks into an AI-accessible knowledge base:
 - **List all your notebooks, sections, and pages**
 - **Read page content** for analysis and search
+- **Read-only by default** for safer first-time setup
 - **Natural language queries** like "Show me my DevOps notes" or "Find pages about project planning"
 - **Secure OAuth authentication** with Microsoft Graph API
 - **Bulletproof error handling** with detailed debugging
@@ -64,8 +65,8 @@ Still in your Azure app:
 2. Select **Microsoft Graph** → **Delegated permissions**
 3. Add these permissions:
    - `Notes.Read` - Read OneNote notebooks
-   - `Notes.ReadWrite` - Create/modify OneNote content (optional but recommended)
    - `User.Read` - Read user profile
+   - `Notes.ReadWrite` - Create/modify OneNote content (optional; only needed when write mode is enabled)
 4. Click **Grant admin consent** (the button at the top)
 
 ### 5. Configure Claude Desktop
@@ -94,6 +95,8 @@ Add this configuration (replace `/ABSOLUTE/PATH/TO/PARENT/FOLDER/weather` with y
 }
 ```
 
+The default configuration is read-only and requests only `Notes.Read` and `User.Read` scopes.
+
 **With explicit token caching control:**
 ```json
 {
@@ -114,6 +117,31 @@ Add this configuration (replace `/ABSOLUTE/PATH/TO/PARENT/FOLDER/weather` with y
 ```
 
 Replace `/FULL/PATH/TO/onenote-mcp-server` with the actual path to this project.
+
+### Codex and Other MCP Clients
+
+For MCP clients that accept the standard `mcpServers` JSON shape, you can use `mcp_config.example.json` as a starting point. It points directly at the local virtual environment Python executable, which avoids relying on `uv` being available in the GUI app's PATH.
+
+**Enable OneNote write tools:**
+```json
+{
+  "mcpServers": {
+    "onenote": {
+      "command": "uv",
+      "args": [
+        "--directory", "/FULL/PATH/TO/onenote-mcp-server",
+        "run", "python", "onenote_mcp_server.py"
+      ],
+      "env": {
+        "AZURE_CLIENT_ID": "your-azure-client-id-here",
+        "ONENOTE_ENABLE_WRITE": "true"
+      }
+    }
+  }
+}
+```
+
+When `ONENOTE_ENABLE_WRITE=true`, the server requests `Notes.ReadWrite` and enables tools that create or update notebooks, sections, and pages. If you previously authenticated in read-only mode, clear the token cache and authenticate again so Microsoft can grant the expanded scope.
 
 ### 6. Restart Claude Desktop
 Completely quit and restart Claude Desktop. You should see OneNote tools in the 🔨 menu.
@@ -156,6 +184,14 @@ By default, authentication tokens are cached securely on your local machine so y
 **Token caching options:**
 - `ONENOTE_CACHE_TOKENS=true` (default) - Tokens persist across sessions
 - `ONENOTE_CACHE_TOKENS=false` - Authenticate every session (more secure)
+
+### Write Access
+
+Write access is disabled by default. This is intentional so the first run can safely inspect your OneNote data without granting modification permissions.
+
+**Write access options:**
+- `ONENOTE_ENABLE_WRITE=false` (default) - Read-only mode; create/update tools return a permissions error
+- `ONENOTE_ENABLE_WRITE=true` - Requests `Notes.ReadWrite` and enables create/update tools
 
 ## 📖 Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ The default configuration is read-only and requests only `Notes.Read` and `User.
       ],
       "env": {
         "AZURE_CLIENT_ID": "your-azure-client-id-here",
-        "ONENOTE_CACHE_TOKENS": "true"
+        "ONENOTE_CACHE_TOKENS": "true",
+        "ONENOTE_TOKEN_CACHE_FILE": "/FULL/PATH/TO/.onenote_mcp_tokens.json"
       }
     }
   }
@@ -184,6 +185,7 @@ By default, authentication tokens are cached securely on your local machine so y
 **Token caching options:**
 - `ONENOTE_CACHE_TOKENS=true` (default) - Tokens persist across sessions
 - `ONENOTE_CACHE_TOKENS=false` - Authenticate every session (more secure)
+- `ONENOTE_TOKEN_CACHE_FILE=/path/to/tokens.json` - Store the token cache at a custom path instead of `~/.onenote_mcp_tokens.json`
 
 ### Write Access
 

--- a/claude_desktop_config.example.json
+++ b/claude_desktop_config.example.json
@@ -7,7 +7,8 @@
         "run", "python", "onenote_mcp_server.py"
       ],
       "env": {
-        "AZURE_CLIENT_ID": "YOUR_AZURE_CLIENT_ID_HERE"
+        "AZURE_CLIENT_ID": "YOUR_AZURE_CLIENT_ID_HERE",
+        "ONENOTE_ENABLE_WRITE": "false"
       }
     }
   }

--- a/mcp_config.example.json
+++ b/mcp_config.example.json
@@ -8,7 +8,7 @@
       "env": {
         "AZURE_CLIENT_ID": "YOUR_AZURE_CLIENT_ID_HERE",
         "ONENOTE_CACHE_TOKENS": "true",
-        "ONENOTE_TOKEN_CACHE_FILE": "/Users/fcagalj/SOFT_DEV/PROJECTS/BlockIncrement/personal-assistant/mcp-secrets/onenote/tokens.json",
+        "ONENOTE_TOKEN_CACHE_FILE": "/Users/fcagalj/SOFT_DEV/PROJECTS/BlockIncrement/personal-assistant/secrets/onenote/tokens.json",
         "ONENOTE_ENABLE_WRITE": "false"
       }
     }

--- a/mcp_config.example.json
+++ b/mcp_config.example.json
@@ -1,10 +1,9 @@
 {
   "mcpServers": {
     "onenote": {
-      "command": "uv",
+      "command": "/Users/fcagalj/SOFT_DEV/TOOLS/onenote-mcp-server/.venv/bin/python",
       "args": [
-        "--directory", "/FULL/PATH/TO/onenote-mcp-server",
-        "run", "python", "onenote_mcp_server.py"
+        "/Users/fcagalj/SOFT_DEV/TOOLS/onenote-mcp-server/onenote_mcp_server.py"
       ],
       "env": {
         "AZURE_CLIENT_ID": "YOUR_AZURE_CLIENT_ID_HERE",

--- a/mcp_config.example.json
+++ b/mcp_config.example.json
@@ -8,6 +8,7 @@
       "env": {
         "AZURE_CLIENT_ID": "YOUR_AZURE_CLIENT_ID_HERE",
         "ONENOTE_CACHE_TOKENS": "true",
+        "ONENOTE_TOKEN_CACHE_FILE": "/Users/fcagalj/SOFT_DEV/PROJECTS/BlockIncrement/personal-assistant/mcp-secrets/onenote/tokens.json",
         "ONENOTE_ENABLE_WRITE": "false"
       }
     }

--- a/onenote_mcp_server.py
+++ b/onenote_mcp_server.py
@@ -37,7 +37,7 @@ SCOPES = READ_SCOPES + ([WRITE_SCOPE] if WRITE_ACCESS_ENABLED else [])
 
 # Token cache configuration
 TOKEN_CACHE_ENABLED = os.getenv("ONENOTE_CACHE_TOKENS", "true").lower() in ("true", "1", "yes")
-TOKEN_CACHE_FILE = Path.home() / ".onenote_mcp_tokens.json"
+TOKEN_CACHE_FILE = Path(os.getenv("ONENOTE_TOKEN_CACHE_FILE", str(Path.home() / ".onenote_mcp_tokens.json"))).expanduser()
 
 # Global variables for authentication
 access_token: Optional[str] = None
@@ -67,6 +67,8 @@ def save_tokens(access_tok: str, refresh_tok: str = None, expires_in: int = 3600
         return
     
     try:
+        TOKEN_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+
         token_data = {
             "access_token": access_token,
             "refresh_token": refresh_token,

--- a/onenote_mcp_server.py
+++ b/onenote_mcp_server.py
@@ -10,6 +10,7 @@ import os
 import asyncio
 import json
 import logging
+from html import escape
 from typing import List, Dict, Any, Optional
 from pathlib import Path
 import time
@@ -26,11 +27,13 @@ mcp = FastMCP("OneNote MCP Server")
 
 # Microsoft Graph API constants
 GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
-SCOPES = [
+READ_SCOPES = [
     "https://graph.microsoft.com/Notes.Read",
-    "https://graph.microsoft.com/Notes.ReadWrite",
     "https://graph.microsoft.com/User.Read"
 ]
+WRITE_SCOPE = "https://graph.microsoft.com/Notes.ReadWrite"
+WRITE_ACCESS_ENABLED = os.getenv("ONENOTE_ENABLE_WRITE", "false").lower() in ("true", "1", "yes")
+SCOPES = READ_SCOPES + ([WRITE_SCOPE] if WRITE_ACCESS_ENABLED else [])
 
 # Token cache configuration
 TOKEN_CACHE_ENABLED = os.getenv("ONENOTE_CACHE_TOKENS", "true").lower() in ("true", "1", "yes")
@@ -226,6 +229,14 @@ async def ensure_valid_token() -> bool:
     access_token = None
     return False
 
+def require_write_access() -> None:
+    """Raise if write tools are disabled for this server process."""
+    if not WRITE_ACCESS_ENABLED:
+        raise PermissionError(
+            "Write access is disabled. Set ONENOTE_ENABLE_WRITE=true and re-authenticate "
+            "with Notes.ReadWrite permission to use this tool."
+        )
+
 # Global variable to store the current authentication flow
 current_flow = None
 
@@ -359,6 +370,7 @@ async def check_authentication() -> str:
     try:
         cache_status = "enabled" if TOKEN_CACHE_ENABLED else "disabled"
         cache_file_exists = TOKEN_CACHE_FILE.exists() if TOKEN_CACHE_ENABLED else False
+        write_status = "enabled" if WRITE_ACCESS_ENABLED else "disabled"
         
         if await ensure_valid_token():
             try:
@@ -372,6 +384,8 @@ async def check_authentication() -> str:
                     "token_valid_for_seconds": max(0, time_until_expiry),
                     "token_valid_for_hours": round(max(0, time_until_expiry) / 3600, 1),
                     "token_caching": cache_status,
+                    "write_access": write_status,
+                    "requested_scopes": SCOPES,
                     "cache_file_exists": cache_file_exists,
                     "cache_file_path": str(TOKEN_CACHE_FILE) if TOKEN_CACHE_ENABLED else "N/A"
                 }, indent=2)
@@ -381,13 +395,17 @@ async def check_authentication() -> str:
                     "status": "token_invalid",
                     "error": str(graph_error),
                     "message": "Token exists but API call failed - may need re-authentication",
-                    "token_caching": cache_status
+                    "token_caching": cache_status,
+                    "write_access": write_status,
+                    "requested_scopes": SCOPES
                 }, indent=2)
         else:
             return json.dumps({
                 "status": "not_authenticated",
                 "message": "No valid authentication token. Please call 'start_authentication'",
                 "token_caching": cache_status,
+                "write_access": write_status,
+                "requested_scopes": SCOPES,
                 "cache_file_exists": cache_file_exists
             }, indent=2)
             
@@ -395,7 +413,8 @@ async def check_authentication() -> str:
         return json.dumps({
             "status": "error",
             "error": str(e),
-            "token_caching": "unknown"
+            "token_caching": "unknown",
+            "write_access": "unknown"
         }, indent=2)
 
 async def make_graph_request(endpoint: str, method: str = "GET", data: Dict = None) -> Dict:
@@ -524,6 +543,9 @@ async def get_page_content(page_id: str) -> str:
         Page content as HTML or error message
     """
     try:
+        if not await ensure_valid_token():
+            return "Error getting page content: Not authenticated. Please call 'start_authentication' and 'complete_authentication' first."
+
         # Get page content (returns HTML)
         async with httpx.AsyncClient() as client:
             headers = {"Authorization": f"Bearer {access_token}"}
@@ -584,6 +606,8 @@ async def create_notebook(name: str, description: str = None) -> str:
         JSON string with the created notebook information
     """
     try:
+        require_write_access()
+
         data = {"displayName": name}
         if description:
             data["description"] = description
@@ -618,6 +642,8 @@ async def create_section(notebook_id: str, name: str) -> str:
         JSON string with the created section information
     """
     try:
+        require_write_access()
+
         data = {"displayName": name}
         
         section = await make_graph_request(
@@ -655,6 +681,12 @@ async def create_page(section_id: str, title: str, content_html: str = None) -> 
         JSON string with the created page information
     """
     try:
+        require_write_access()
+        if not await ensure_valid_token():
+            return "Error creating page: Not authenticated. Please call 'start_authentication' and 'complete_authentication' first."
+
+        escaped_title = escape(title)
+
         # Build the HTML structure for the page
         if content_html:
             # Ensure content is wrapped in proper OneNote HTML structure
@@ -663,12 +695,12 @@ async def create_page(section_id: str, title: str, content_html: str = None) -> 
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{title}</title>
+    <title>{escaped_title}</title>
     <meta name="created" content="{time.strftime('%Y-%m-%dT%H:%M:%S.0000000')}" />
 </head>
 <body>
     <div>
-        <h1>{title}</h1>
+        <h1>{escaped_title}</h1>
         <div>{content_html}</div>
     </div>
 </body>
@@ -681,12 +713,12 @@ async def create_page(section_id: str, title: str, content_html: str = None) -> 
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{title}</title>
+    <title>{escaped_title}</title>
     <meta name="created" content="{time.strftime('%Y-%m-%dT%H:%M:%S.0000000')}" />
 </head>
 <body>
     <div>
-        <h1>{title}</h1>
+        <h1>{escaped_title}</h1>
         <p>Page created by OneNote MCP Server</p>
     </div>
 </body>
@@ -740,6 +772,10 @@ async def update_page_content(page_id: str, content_html: str, target_element: s
         Status message
     """
     try:
+        require_write_access()
+        if not await ensure_valid_token():
+            return "Error updating page content: Not authenticated. Please call 'start_authentication' and 'complete_authentication' first."
+
         # OneNote PATCH API for updating page content
         patch_data = [
             {
@@ -779,7 +815,8 @@ def main():
     """Main entry point for the server."""
     # Log token caching configuration
     cache_status = "enabled" if TOKEN_CACHE_ENABLED else "disabled"
-    logger.info(f"OneNote MCP Server starting - Token caching: {cache_status}")
+    write_status = "enabled" if WRITE_ACCESS_ENABLED else "disabled"
+    logger.info(f"OneNote MCP Server starting - Token caching: {cache_status}, write access: {write_status}")
     
     if TOKEN_CACHE_ENABLED:
         logger.info(f"Token cache file: {TOKEN_CACHE_FILE}")


### PR DESCRIPTION
This change makes the server safer for first-time setup by defaulting it to read-only Microsoft Graph scopes:

- default scopes are now `Notes.Read` and `User.Read`
- `Notes.ReadWrite` is only requested when `ONENOTE_ENABLE_WRITE=true`
- create/update tools now return a clear permissions error unless write mode is explicitly enabled
- `check_authentication` reports the active write mode and requested scopes so users can verify what the server is asking Microsoft for
- direct page content/create/update paths now validate authentication before making Graph calls
- page title HTML is escaped when generating new page HTML
- docs and example configs now describe the read-only default, write opt-in behavior, and token re-authentication requirement after enabling write mode
- added `mcp_config.example.json` for MCP clients that use the standard `mcpServers` shape and may not have `uv` available in the GUI app PATH

I made the default conservative because many users will want to inspect OneNote content before granting modification permissions. Users who need write tools can still enable them explicitly with `ONENOTE_ENABLE_WRITE=true`, clear cached tokens if they previously authenticated read-only, and then authenticate again to grant `Notes.ReadWrite`.

Validation I ran locally:

```bash
python3 -m py_compile onenote_mcp_server.py
.venv/bin/python -m json.tool mcp_config.example.json >/dev/null
.venv/bin/python -m json.tool claude_desktop_config.example.json >/dev/null
.venv/bin/python -m json.tool claude_desktop_config_with_caching.example.json >/dev/null
.venv/bin/python -c "import onenote_mcp_server as s; assert not s.WRITE_ACCESS_ENABLED; assert 'https://graph.microsoft.com/Notes.ReadWrite' not in s.SCOPES"
ONENOTE_ENABLE_WRITE=true .venv/bin/python -c "import onenote_mcp_server as s; assert s.WRITE_ACCESS_ENABLED; assert 'https://graph.microsoft.com/Notes.ReadWrite' in s.SCOPES"
```
